### PR TITLE
Improve abstract extraction

### DIFF
--- a/selection/logic/tests.py
+++ b/selection/logic/tests.py
@@ -11,7 +11,12 @@ from selection.logic.openalex_matching import load_tfidf_cosine_match
 
 from .pdf import PDF, bbox
 
-EXAMPLE_MANUSCRIPT = Path(os.getenv("EXAMPLE_MANUSCRIPT_PATH", "."))
+EXAMPLE_MANUSCRIPT = Path(
+    os.getenv(
+        "EXAMPLE_MANUSCRIPT_PATH",
+        Path(__file__).parents[3] / "reviewerSelection-data" / "EXAMPLE_MANUSCRIPT",
+    )
+)
 
 
 def test_python_api():


### PR DESCRIPTION
The abstract detection now works based on either a cue element (i.e. `Abstract:`) or based on the biggest chunk of text with equal line-spacing. This finally creates accurate results for most articles. AJS journal abstracts are now detected properly. 